### PR TITLE
Support parsing XBRL documents with multiple context references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+## Version 1.0.3
+* Support parsing XBRL documents that may contain multiple context references (e.g. Alphabet/Google)

--- a/index.js
+++ b/index.js
@@ -70,10 +70,16 @@
       var concept = _.get(self.documentJson, 'dei:' + conceptToFind);
       //console.log(fieldName + "=> " + JSON.stringify(concept, null, 3));
       if(_.isArray(concept)) {
-        // Default to the first available contextRef
+        // warn about multliple concepts...
         console.warn('Found ' + concept.length + ' context references')
-        _.forEach(concept, function(c, idx) { console.warn('=> ' + c.contextRef + (idx === 0 ? ' (selected)' : ''))});
-        concept = _.find(concept, function(c, idx) { return idx === 0; });
+        _.forEach(concept, function(conceptInstance, idx) { 
+          console.warn('=> ' + conceptInstance.contextRef + (idx === 0 ? ' (selected)' : ''));
+        });
+        
+        // ... then default to the first available contextRef
+        concept = _.find(concept, function(conceptInstance, idx) { 
+          return idx === 0; 
+        });
       }
       self.fields[fieldName] = _.get(concept, key, 'Field not found.');
       

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@
           reject('No year end found.')
         }
       }).catch(function(err) {
-          reject('Problem with reading file', err);
+          reject('Problem with reading file\n' + err);
       })
     })
 
@@ -67,7 +67,17 @@
     function loadField(conceptToFind, fieldName, key) {
       key = key || '$t';
       fieldName = fieldName || conceptToFind;
-      self.fields[fieldName] = _.get(self.documentJson, ['dei:' + conceptToFind, key], 'Field not found.');
+      var concept = _.get(self.documentJson, 'dei:' + conceptToFind);
+      //console.log(fieldName + "=> " + JSON.stringify(concept, null, 3));
+      if(_.isArray(concept)) {
+        // Default to the first available contextRef
+        console.warn('Found ' + concept.length + ' context references')
+        _.forEach(concept, function(c, idx) { console.warn('=> ' + c.contextRef + (idx === 0 ? ' (selected)' : ''))});
+        concept = _.find(concept, function(c, idx) { return idx === 0; });
+      }
+      self.fields[fieldName] = _.get(concept, key, 'Field not found.');
+      
+      console.log(`loaded ${fieldName}: ${self.fields[fieldName]}`);
     }
 
     function getFactValue(concept, periodType) {
@@ -108,7 +118,7 @@
     };
 
     function loadYear() {
-      var currentEnd = _.get(self.documentJson, ['dei:DocumentPeriodEndDate', '$t']);
+      var currentEnd = self.fields['DocumentPeriodEndDate'];
       if ((currentEnd).match(/(\d{4})-(\d{1,2})-(\d{1,2})/)) {
         return currentEnd;
       } else {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parse-xbrl",
   "description": "Module to parse xbrl documents and output json.",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "dependencies": {
     "bluebird": "^3.3.1",
     "fs": "0.0.2",

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -488,6 +488,76 @@ var rubyTuesday10qParsed = {
  'FiscalYear':'--05-31'
 }
 
+var google10kParsed = {
+ 'NetCashFlowsContinuing':-1364000000 ,
+ 'NetCashFlowsFinancingDiscontinued':0,
+ 'NetIncomeAvailableToCommonStockholdersBasic':15826000000,
+ 'NonoperatingIncomeLossPlusInterestAndDebtExpense':291000000,
+ 'NoncurrentLiabilities':7820000000,
+ 'IncomeFromContinuingOperationsBeforeTax':19651000000,
+ 'ContextForInstants':'FI2015Q4',
+ 'Equity':120331000000,
+ 'EntityFilerCategory':'Large Accelerated Filer',
+ 'DocumentType':'10-K',
+ 'ContextForDurations':'FD2015Q4YTD',
+ 'NetCashFlowsOperatingContinuing':26024000000,
+ 'OtherComprehensiveIncome':-1901000000,
+ 'ComprehensiveIncomeAttributableToNoncontrollingInterest':0,
+ 'NetCashFlowsInvestingContinuing':-23711000000,
+ 'ROS':0.21800530744509194,
+ 'NetIncomeAttributableToParent':16348000000,
+ 'SGR':0.15721800678957132,
+ 'NetCashFlowsInvestingDiscontinued':0,
+ 'ROE':0.13585859005576287,
+ 'PreferredStockDividendsAndOtherAdjustments':0,
+ 'NonoperatingIncomePlusInterestAndDebtExpensePlusIncomeFromEquityMethodInvestments':291000000,
+ 'NetCashFlowsOperating':26024000000,
+ 'CostsAndExpenses':55629000000,
+ 'CurrentAssets':90114000000,
+ 'IncomeFromEquityMethodInvestments':0,
+ 'NoncurrentAssets':57347000000,
+ 'EntityRegistrantName':'Alphabet Inc.',
+ 'IncomeTaxExpenseBenefit':3303000000,
+ 'CostOfRevenue':0,
+ 'ExchangeGainsLosses':0,
+ 'CurrentLiabilities':19310000000,
+ 'Assets':147461000000,
+ 'NetCashFlowsDiscontinued':0,
+ 'LiabilitiesAndEquity':147461000000,
+ 'OperatingIncomeLoss':19360000000,
+ 'TemporaryEquity':0,
+ 'NonoperatingIncomeLoss':0,
+ 'OtherOperatingIncome':0,
+ 'EquityAttributableToParent':120331000000,
+ 'GrossProfit':0,
+ 'TradingSymbol':'GOOG, GOOGL',
+ 'NetCashFlow':-1798000000,
+ 'DocumentFiscalYearFocus':'2015',
+ 'IncomeFromDiscontinuedOperations':0,
+ 'NetCashFlowsInvesting':-23711000000,
+ 'ComprehensiveIncome':14447000000,
+ 'Revenues':74989000000,
+ 'CommitmentsAndContingencies':0,
+ 'OperatingExpenses':0,
+ 'IncomeStatementPeriodYTD':'2015-01-01',
+ 'Liabilities':27130000000,
+ 'NetCashFlowsFinancingContinuing':-3677000000,
+ 'EntityCentralIndexKey':'0001652044',
+ 'EquityAttributableToNoncontrollingInterest':0,
+ 'ComprehensiveIncomeAttributableToParent':14447000000,
+ 'DocumentFiscalPeriodFocus':'FY',
+ 'NetIncomeLoss':16348000000,
+ 'IncomeBeforeEquityMethodInvestments':19651000000,
+ 'NetCashFlowsOperatingDiscontinued':0,
+ 'BalanceSheetDate':'2015-12-31',
+ 'NetCashFlowsFinancing':-3677000000,
+ 'ROA':0.11086321128976476,
+ 'ExtraordaryItemsGainLoss':0,
+ 'IncomeFromContinuingOperationsAfterTax':16348000000,
+ 'NetIncomeAttributableToNoncontrollingInterest':0,
+ 'InterestAndDebtExpense':0
+}
+
 describe('parse-xbrl', function () {
 
   it('should parse the xbrl for Amazon 10k', function (done) {
@@ -568,6 +638,18 @@ describe('parse-xbrl', function () {
       for (var key in results) {
         if (rubyTuesday10qParsed[key]) {
           expect(results[key]).toBe(rubyTuesday10qParsed[key]);
+          done();
+        }
+      }
+    })
+  })
+  
+  it('should parse the xbrl for Google/Alphabet 10k', function (done) {
+    var google10kOutput = ParseXbrl.parse('./test/sampleXbrlDocuments/google_10k.xml');
+    google10kOutput.then(function(results) {
+      for (var key in results) {
+        if (google10kParsed[key]) {
+          expect(results[key]).toBe(google10kParsed[key]);
           done();
         }
       }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -374,7 +374,7 @@ var sweetsAndTreats10qParsed = {
  'CurrentAssets':5806,
  'IncomeFromEquityMethodInvestments':0,
  'NoncurrentAssets':0,
- 'EntityRegistrantName':'SWEETS &amp; TREATS INC.',
+ 'EntityRegistrantName':'SWEETS & TREATS INC.',
  'IncomeTaxExpenseBenefit':0,
  'CostOfRevenue':99,
  'ExchangeGainsLosses':0,


### PR DESCRIPTION
I found that `parse-xbrl` was crashing on Alphabet/Google's most recent 10K with the following error: `Problem with reading file`.   This was a little tricky to troubleshoot as attempts to debug with `node-inspector` apparently triggered some kind of buffer limit with the large Google 10K document in memory but after some old-fashioned console debugging I tracked the problem down to this XML:

```
<dei:DocumentPeriodEndDate contextRef="FD2015Q4YTD" id="Fact-9827D42F5FD282F5186ECA515011FA70">2015-12-31</dei:DocumentPeriodEndDate>
    <dei:DocumentPeriodEndDate contextRef="FD2015Q4YTD_dei_LegalEntityAxis_us-gaap_SubsidiariesMember" id="Fact-22FB23C7D6629E3FF1D2A4A0F6BEE55C">2015-12-31</dei:DocumentPeriodEndDate>
```

getting turned into this JSON:

```
"dei:DocumentPeriodEndDate":[
   {"contextRef":"FD2015Q4YTD",
    "id":"Fact-9827D42F5FD282F5186ECA515011FA70",
    "$t":"2015-12-31"
   },
   {"contextRef":"FD2015Q4YTD_dei_LegalEntityAxis_us-gaap_SubsidiariesMember",
    "id":"Fact-22FB23C7D6629E3FF1D2A4A0F6BEE55C",
    "$t":"2015-12-31"}
]
```

which was causing some of the parsing logic in `loadField` and `loadYear` to fail.

This PR resolves the issue by defaulting to the first available context reference node after outputting a warning message that multiple context references were found.   The Google 10K in which I discovered the issue has also been added to the test XBRL documents and the unit test have been updated.   I also tweaked the promise rejection to join the "Problem with reading file" message and the error itself in the event that some future error falls into that code.

Let me know if there are any further changes you'd like to see before accepting the PR.
Thanks!
- James
